### PR TITLE
Task 05: UDF + single UiState + injected dispatchers

### DIFF
--- a/base/src/main/java/com/timhome/base/BaseComponent.kt
+++ b/base/src/main/java/com/timhome/base/BaseComponent.kt
@@ -6,8 +6,11 @@ import com.timhome.core.data.repository.ArduinoRepository
 import com.timhome.core.di.CoreComponent
 import com.timhome.core.common.FeatureScope
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.di.DefaultDispatcher
+import com.timhome.core.common.di.IoDispatcher
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.Component
+import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 
@@ -21,6 +24,12 @@ interface BaseComponent {
     val arduinoRepository: ArduinoRepository
     val firebaseAnalytics: FirebaseAnalytics
     val navigationDispatcher: NavigationDispatcher
+
+    @IoDispatcher
+    fun ioDispatcher(): CoroutineDispatcher
+
+    @DefaultDispatcher
+    fun defaultDispatcher(): CoroutineDispatcher
 
     @Component.Factory
     interface Factory {

--- a/core/common/src/main/java/com/timhome/core/common/di/Dispatcher.kt
+++ b/core/common/src/main/java/com/timhome/core/common/di/Dispatcher.kt
@@ -1,0 +1,11 @@
+package com.timhome.core.common.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DefaultDispatcher

--- a/core/src/main/java/com/timhome/core/di/CoreComponent.kt
+++ b/core/src/main/java/com/timhome/core/di/CoreComponent.kt
@@ -7,15 +7,18 @@ import com.timhome.core.datastore.DataStoreManager
 import com.timhome.core.network.api.ArduinoApi
 import com.timhome.core.network.di.NetworkModule
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.di.DefaultDispatcher
+import com.timhome.core.common.di.IoDispatcher
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 
 @Singleton
-@Component(modules = [NetworkModule::class, DatabaseModule::class, AppModule::class])
+@Component(modules = [NetworkModule::class, DatabaseModule::class, AppModule::class, DispatchersModule::class])
 interface CoreComponent {
     val retrofit: Retrofit
     val okHttpClient: OkHttpClient
@@ -24,6 +27,12 @@ interface CoreComponent {
     val arduinoApi: ArduinoApi
     val firebaseAnalytics: FirebaseAnalytics
     val navigationDispatcher: NavigationDispatcher
+
+    @IoDispatcher
+    fun ioDispatcher(): CoroutineDispatcher
+
+    @DefaultDispatcher
+    fun defaultDispatcher(): CoroutineDispatcher
 
     @Component.Factory
     interface Factory {

--- a/core/src/main/java/com/timhome/core/di/DispatchersModule.kt
+++ b/core/src/main/java/com/timhome/core/di/DispatchersModule.kt
@@ -1,0 +1,22 @@
+package com.timhome.core.di
+
+import com.timhome.core.common.di.DefaultDispatcher
+import com.timhome.core.common.di.IoDispatcher
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+class DispatchersModule {
+    @Singleton
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Singleton
+    @Provides
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleScreen.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleScreen.kt
@@ -57,8 +57,9 @@ internal fun BuyModuleScreen(
     viewModel: BuyModuleViewModel = viewModel(factory = abstractFactory.get()),
 ) {
     HomeTheme {
-        val totalPrice by viewModel.totalPrice.collectAsStateWithLifecycle()
-        val modules by viewModel.modules.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+        val totalPrice = state.totalPrice
+        val modules = state.modules
 
         Scaffold(
             topBar = {

--- a/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleViewModel.kt
@@ -11,12 +11,21 @@ import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
+
+internal data class BuyModuleUiState(
+    val totalPrice: BigDecimal = BigDecimal.ZERO,
+    val modules: ImmutableList<ModuleModel> = persistentListOf(),
+)
 
 internal class BuyModuleViewModel
     @AssistedInject
@@ -25,8 +34,8 @@ internal class BuyModuleViewModel
         private val navigationDispatcher: NavigationDispatcher,
         private val repository: IDeviceRepository,
     ) : ViewModel() {
-        val totalPrice = MutableStateFlow<BigDecimal>(BigDecimal.ZERO)
-        val modules = MutableStateFlow(listOf<ModuleModel>().toImmutableList())
+        private val _uiState = MutableStateFlow(BuyModuleUiState())
+        val uiState: StateFlow<BuyModuleUiState> = _uiState.asStateFlow()
 
         init {
             val deviceId = savedStateHandle.get<Int>(SELECTED_DEVICE_ID)
@@ -38,13 +47,11 @@ internal class BuyModuleViewModel
 
             viewModelScope.launch {
                 selectedModules.stateIn(viewModelScope).collect { list ->
-                    totalPrice.update {
-                        list.sumOf {
-                            BigDecimal(it.price.replace("$", ""))
-                        }
-                    }
-                    modules.update {
-                        list.toImmutableList()
+                    _uiState.update {
+                        it.copy(
+                            totalPrice = list.sumOf { module -> BigDecimal(module.price.replace("$", "")) },
+                            modules = list.toImmutableList(),
+                        )
                     }
                 }
             }

--- a/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailScreen.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailScreen.kt
@@ -30,8 +30,9 @@ internal fun DeviceDetailScreen(
     viewModel: DeviceDetailViewModel = viewModel(factory = abstractFactory.get()),
 ) {
     HomeTheme {
-        val device by viewModel.device.collectAsStateWithLifecycle()
-        val modules by viewModel.module.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+        val device = state.device
+        val modules = state.modules
 
         if (device == null) return@HomeTheme
         Scaffold(

--- a/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.di.IoDispatcher
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.device.data.model.ModuleModel
 import com.timhome.device.domain.IDeviceRepository
@@ -12,12 +13,21 @@ import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+internal data class DeviceDetailUiState(
+    val device: DeviceModel? = null,
+    val modules: ImmutableList<ModuleModel> = persistentListOf(),
+)
 
 internal class DeviceDetailViewModel
     @AssistedInject
@@ -25,27 +35,25 @@ internal class DeviceDetailViewModel
         @Assisted private val savedStateHandle: SavedStateHandle,
         private val navigationDispatcher: NavigationDispatcher,
         private val repository: IDeviceRepository,
+        @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
         private val deviceId: Int? = savedStateHandle.get<Int>(SELECTED_DEVICE_ID)
-        val device = MutableStateFlow<DeviceModel?>(null)
-        val module = MutableStateFlow(listOf<ModuleModel>().toImmutableList())
+
+        private val _uiState = MutableStateFlow(DeviceDetailUiState())
+        val uiState: StateFlow<DeviceDetailUiState> = _uiState.asStateFlow()
 
         init {
             if (deviceId != null) {
-                viewModelScope.launch(Dispatchers.IO) {
+                viewModelScope.launch(ioDispatcher) {
                     getSelectedDeviceById(deviceId)
                 }
             }
         }
 
         private suspend fun getSelectedDeviceById(deviceId: Int) {
-            device.update {
-                repository.getDeviceById(deviceId)
-            }
+            _uiState.update { it.copy(device = repository.getDeviceById(deviceId)) }
             repository.getModuleToBuyByDeviceId(deviceId).stateIn(viewModelScope).collect { modules ->
-                module.update {
-                    modules.toImmutableList()
-                }
+                _uiState.update { it.copy(modules = modules.toImmutableList()) }
             }
         }
 

--- a/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListScreen.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListScreen.kt
@@ -26,7 +26,8 @@ internal fun DeviceListScreen(
     viewModel: DeviceListViewModel = viewModel(factory = abstractFactory.get()),
 ) {
     HomeTheme {
-        val deviceList by viewModel.deviceList.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+        val deviceList = state.devices
 
         LazyColumn(
             modifier = Modifier.fillMaxSize().testTag("device_list"),

--- a/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.di.IoDispatcher
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.device.data.repository.DeviceRepository
 import com.timhome.device.domain.models.DeviceModel
@@ -12,12 +13,19 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+internal data class DeviceListUiState(
+    val devices: ImmutableList<DeviceModel> = persistentListOf(),
+)
 
 internal class DeviceListViewModel
     @AssistedInject
@@ -25,19 +33,21 @@ internal class DeviceListViewModel
         @Assisted private val savedStateHandle: SavedStateHandle,
         private val navigationDispatcher: NavigationDispatcher,
         private val repository: DeviceRepository,
+        @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
         firebaseAnalytics: FirebaseAnalytics,
     ) : ViewModel() {
-        val deviceList = MutableStateFlow(listOf<DeviceModel>().toImmutableList())
+        private val _uiState = MutableStateFlow(DeviceListUiState())
+        val uiState: StateFlow<DeviceListUiState> = _uiState.asStateFlow()
 
         init {
             firebaseAnalytics.logEvent(
                 FirebaseAnalytics.Event.SCREEN_VIEW,
                 bundleOf(Pair(FirebaseAnalytics.Param.SCREEN_NAME, "device_list")),
             )
-            viewModelScope.launch(Dispatchers.IO) {
+            viewModelScope.launch(ioDispatcher) {
                 repository.getAllDevices().stateIn(viewModelScope).collect { list ->
                     if (list.isEmpty()) repository.initAllDevices()
-                    deviceList.update { list }
+                    _uiState.update { it.copy(devices = list) }
                 }
             }
         }

--- a/feature/device/src/test/java/com/timhome/device/ui/buyModule/BuyModuleViewModelTest.kt
+++ b/feature/device/src/test/java/com/timhome/device/ui/buyModule/BuyModuleViewModelTest.kt
@@ -1,0 +1,98 @@
+package com.timhome.device.ui.buyModule
+
+import androidx.lifecycle.SavedStateHandle
+import com.timhome.core.common.NavigationDispatcher
+import com.timhome.device.data.model.ModuleModel
+import com.timhome.device.domain.IDeviceRepository
+import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+
+class BuyModuleViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: IDeviceRepository = mockk(relaxed = true)
+    private val navigationDispatcher = NavigationDispatcher()
+
+    private val moduleA =
+        ModuleModel(id = 1, title = "A", price = "$3", link = "l", isSelectToBuy = true)
+    private val moduleB =
+        ModuleModel(id = 2, title = "B", price = "$4", link = "l", isSelectToBuy = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(deviceId: Int?): BuyModuleViewModel {
+        val handle = SavedStateHandle()
+        if (deviceId != null) handle[SELECTED_DEVICE_ID] = deviceId
+        return BuyModuleViewModel(handle, navigationDispatcher, repository)
+    }
+
+    @Test
+    fun `sums prices and exposes modules for a device`() =
+        runTest {
+            every { repository.getSelectedModuleToBuyByDeviceId(7) } returns flowOf(listOf(moduleA, moduleB))
+
+            val viewModel = createViewModel(deviceId = 7)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(BigDecimal(7), viewModel.uiState.value.totalPrice)
+            assertEquals(listOf(moduleA, moduleB), viewModel.uiState.value.modules)
+        }
+
+    @Test
+    fun `falls back to global selection when no deviceId`() =
+        runTest {
+            every { repository.getSelectedModuleToBuy() } returns flowOf(listOf(moduleA))
+
+            val viewModel = createViewModel(deviceId = null)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(BigDecimal(3), viewModel.uiState.value.totalPrice)
+            assertEquals(listOf(moduleA), viewModel.uiState.value.modules)
+        }
+
+    @Test
+    fun `removeModule delegates to repository`() =
+        runTest {
+            every { repository.getSelectedModuleToBuy() } returns flowOf(emptyList())
+
+            val viewModel = createViewModel(deviceId = null)
+
+            viewModel.removeModule(moduleA)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            coVerify { repository.selectModuleToBuy(moduleA) }
+        }
+
+    @Test
+    fun `goBack emits a navigation command`() =
+        runTest {
+            every { repository.getSelectedModuleToBuy() } returns flowOf(emptyList())
+
+            val viewModel = createViewModel(deviceId = null)
+
+            viewModel.goBack()
+
+            assertNotNull(navigationDispatcher.navigationEmitter.tryReceive().getOrNull())
+        }
+}

--- a/feature/device/src/test/java/com/timhome/device/ui/device/DeviceDetailViewModelTest.kt
+++ b/feature/device/src/test/java/com/timhome/device/ui/device/DeviceDetailViewModelTest.kt
@@ -1,0 +1,117 @@
+package com.timhome.device.ui.device
+
+import androidx.lifecycle.SavedStateHandle
+import com.timhome.core.common.NavigationDispatcher
+import com.timhome.device.data.model.ModuleModel
+import com.timhome.device.domain.IDeviceRepository
+import com.timhome.device.domain.models.DeviceModel
+import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class DeviceDetailViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: IDeviceRepository = mockk(relaxed = true)
+    private val navigationDispatcher = NavigationDispatcher()
+
+    private val device =
+        DeviceModel(id = 1, image = 0, title = "Device", totalPrice = "$10", dateCreated = "today")
+    private val module =
+        ModuleModel(id = 5, title = "Module", price = "$3", link = "link", isSelectToBuy = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(deviceId: Int? = 1): DeviceDetailViewModel {
+        val handle = SavedStateHandle()
+        if (deviceId != null) handle[SELECTED_DEVICE_ID] = deviceId
+        return DeviceDetailViewModel(handle, navigationDispatcher, repository, dispatcher)
+    }
+
+    @Test
+    fun `initial state is empty before loading`() =
+        runTest {
+            coEvery { repository.getDeviceById(1) } returns device
+            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
+
+            val viewModel = createViewModel()
+
+            assertEquals(DeviceDetailUiState(), viewModel.uiState.value)
+        }
+
+    @Test
+    fun `loads device and modules when deviceId is present`() =
+        runTest {
+            coEvery { repository.getDeviceById(1) } returns device
+            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
+
+            val viewModel = createViewModel()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(device, viewModel.uiState.value.device)
+            assertEquals(listOf(module), viewModel.uiState.value.modules)
+        }
+
+    @Test
+    fun `does not load anything when deviceId is absent`() =
+        runTest {
+            val viewModel = createViewModel(deviceId = null)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.device)
+            coVerify(exactly = 0) { repository.getDeviceById(any()) }
+        }
+
+    @Test
+    fun `selectModuleToBuy delegates to repository`() =
+        runTest {
+            val viewModel = createViewModel(deviceId = null)
+
+            viewModel.selectModuleToBuy(module)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            coVerify { repository.selectModuleToBuy(module) }
+        }
+
+    @Test
+    fun `buyModules emits a navigation command`() =
+        runTest {
+            coEvery { repository.getDeviceById(1) } returns device
+            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
+            val viewModel = createViewModel()
+
+            viewModel.buyModules()
+
+            assertNotNull(navigationDispatcher.navigationEmitter.tryReceive().getOrNull())
+        }
+
+    @Test
+    fun `goBack emits a navigation command`() =
+        runTest {
+            val viewModel = createViewModel(deviceId = null)
+
+            viewModel.goBack()
+
+            assertNotNull(navigationDispatcher.navigationEmitter.tryReceive().getOrNull())
+        }
+}

--- a/feature/device/src/test/java/com/timhome/device/ui/listDevice/DeviceListViewModelTest.kt
+++ b/feature/device/src/test/java/com/timhome/device/ui/listDevice/DeviceListViewModelTest.kt
@@ -1,0 +1,86 @@
+package com.timhome.device.ui.listDevice
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.timhome.core.common.NavigationDispatcher
+import com.timhome.device.data.repository.DeviceRepository
+import com.timhome.device.domain.models.DeviceModel
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DeviceListViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: DeviceRepository = mockk(relaxed = true)
+    private val navigationDispatcher = NavigationDispatcher()
+    private val firebaseAnalytics: FirebaseAnalytics = mockk(relaxed = true)
+
+    private val device =
+        DeviceModel(id = 1, image = 0, title = "Device", totalPrice = "$10", dateCreated = "today")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() =
+        DeviceListViewModel(SavedStateHandle(), navigationDispatcher, repository, dispatcher, firebaseAnalytics)
+
+    @Test
+    fun `exposes loaded devices in ui state`() =
+        runTest {
+            every { repository.getAllDevices() } returns flowOf(persistentListOf(device))
+
+            val viewModel = createViewModel()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(persistentListOf(device), viewModel.uiState.value.devices)
+            coVerify(exactly = 0) { repository.initAllDevices() }
+        }
+
+    @Test
+    fun `seeds devices when repository is empty`() =
+        runTest {
+            every { repository.getAllDevices() } returns flowOf(persistentListOf())
+
+            val viewModel = createViewModel()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(persistentListOf<DeviceModel>(), viewModel.uiState.value.devices)
+            coVerify { repository.initAllDevices() }
+        }
+
+    @Test
+    fun `navigateToDetailScreen emits a navigation command`() =
+        runTest {
+            every { repository.getAllDevices() } returns flowOf(persistentListOf(device))
+
+            val viewModel = createViewModel()
+
+            viewModel.navigateToDetailScreen(device)
+
+            assertNotNull(navigationDispatcher.navigationEmitter.tryReceive().getOrNull())
+        }
+}

--- a/feature/home/src/main/java/com/timhome/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/timhome/home/ui/HomeScreen.kt
@@ -49,10 +49,11 @@ internal fun HomeScreen(
     viewModel: HomeViewModel = viewModel(factory = abstractFactory),
 ) {
     HomeTheme {
-        val temperatureInside by viewModel.temperatureInside.collectAsStateWithLifecycle()
-        val temperatureOutside by viewModel.temperatureOutside.collectAsStateWithLifecycle()
-        val co2 by viewModel.co2.collectAsStateWithLifecycle()
-        val chartCO2 by viewModel.measureCO2Levels.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+        val temperatureInside = state.temperatureInside
+        val temperatureOutside = state.temperatureOutside
+        val co2 = state.co2
+        val chartCO2 = state.measureCO2Levels
         val isAnimated = remember { mutableStateOf(false) }
 
         DisposableEffect(key1 = Lifecycle.State.RESUMED) {

--- a/feature/home/src/main/java/com/timhome/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/timhome/home/ui/HomeViewModel.kt
@@ -7,46 +7,56 @@ import androidx.lifecycle.viewModelScope
 import com.timhome.core.database.entity.CarbonDioxideEntity
 import com.timhome.core.data.repository.ArduinoRepository
 import com.timhome.core.common.CallStatus
+import com.timhome.core.common.di.IoDispatcher
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.home.data.repository.WeatherRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlin.math.roundToInt
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+internal data class HomeUiState(
+    val co2: Int = 0,
+    val temperatureInside: Int = 0,
+    val temperatureOutside: Int = 0,
+    val isRefreshing: Boolean = false,
+    val measureCO2Levels: ImmutableList<CarbonDioxideEntity> = persistentListOf(),
+)
 
 internal class HomeViewModel
     @AssistedInject
     constructor(
         private val repository: ArduinoRepository,
         private val weatherRepository: WeatherRepository,
+        @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
         @Assisted private val savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
-        val co2 = MutableStateFlow(0)
-        val temperatureInside = MutableStateFlow(0)
-        val temperatureOutside = MutableStateFlow(0)
-        val isRefreshing = MutableStateFlow(false)
-
-        val measureCO2Levels = MutableStateFlow(listOf<CarbonDioxideEntity>().toImmutableList())
+        private val _uiState = MutableStateFlow(HomeUiState())
+        val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
         init {
             getDate()
         }
 
         private fun getDate() {
-            viewModelScope.launch(Dispatchers.IO) {
-                isRefreshing.update { true }
+            viewModelScope.launch(ioDispatcher) {
+                _uiState.update { it.copy(isRefreshing = true) }
                 val arduino = async { getCO2AndTemperature() }
                 val webTemp = async { getTemperatureOutSide() }
                 awaitAll(arduino, webTemp)
-                isRefreshing.update { false }
+                _uiState.update { it.copy(isRefreshing = false) }
                 getCO2ValuesFromDB()
             }
         }
@@ -54,8 +64,12 @@ internal class HomeViewModel
         private suspend fun getCO2AndTemperature() {
             when (val result = repository.getCo2AndTemperature()) {
                 is CallStatus.Success -> {
-                    temperatureInside.value = result.data?.temperature?.roundToInt() ?: 0
-                    co2.value = result.data?.co2 ?: 0
+                    _uiState.update {
+                        it.copy(
+                            temperatureInside = result.data?.temperature?.roundToInt() ?: 0,
+                            co2 = result.data?.co2 ?: 0,
+                        )
+                    }
                 }
                 is CallStatus.Error -> {
                     Log.e("0909", "getCO2AndTemperature") // TODO show error
@@ -66,7 +80,9 @@ internal class HomeViewModel
         private suspend fun getTemperatureOutSide() {
             when (val result = weatherRepository.getWeather()) {
                 is CallStatus.Success -> {
-                    temperatureOutside.value = result.data?.main?.temp?.roundToInt() ?: 0
+                    _uiState.update {
+                        it.copy(temperatureOutside = result.data?.main?.temp?.roundToInt() ?: 0)
+                    }
                 }
                 is CallStatus.Error -> {
                     Log.e("0909", "getTemperatureOutSide") // TODO
@@ -76,7 +92,9 @@ internal class HomeViewModel
 
         private suspend fun getCO2ValuesFromDB() {
             repository.getCO2ValuesFromDB()
-                .collectLatest { list -> measureCO2Levels.update { list.reversed().toImmutableList() } }
+                .collectLatest { list ->
+                    _uiState.update { it.copy(measureCO2Levels = list.reversed().toImmutableList()) }
+                }
         }
 
         @AssistedFactory

--- a/feature/home/src/test/java/com/timhome/home/ui/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/timhome/home/ui/HomeViewModelTest.kt
@@ -1,0 +1,88 @@
+package com.timhome.home.ui
+
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import com.timhome.core.common.CallStatus
+import com.timhome.core.database.entity.CarbonDioxideEntity
+import com.timhome.core.data.repository.ArduinoRepository
+import com.timhome.core.network.api.response.ArduinoResponse
+import com.timhome.home.data.api.response.MainTemperature
+import com.timhome.home.data.api.response.WeatherResponse
+import com.timhome.home.data.repository.WeatherRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class HomeViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: ArduinoRepository = mockk(relaxed = true)
+    private val weatherRepository: WeatherRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        mockkStatic(Log::class)
+        every { Log.e(any(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    private fun createViewModel() =
+        HomeViewModel(repository, weatherRepository, dispatcher, SavedStateHandle())
+
+    @Test
+    fun `populates ui state from successful calls`() =
+        runTest {
+            coEvery { repository.getCo2AndTemperature() } returns
+                CallStatus.Success(ArduinoResponse(temperature = 21.6, co2 = 800))
+            coEvery { weatherRepository.getWeather() } returns
+                CallStatus.Success(WeatherResponse(MainTemperature(temp = 14.4, pressure = 1000)))
+            every { repository.getCO2ValuesFromDB() } returns
+                flowOf(listOf(CarbonDioxideEntity(co2Level = 1, date = "a"), CarbonDioxideEntity(co2Level = 2, date = "b")))
+
+            val viewModel = createViewModel()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(22, state.temperatureInside)
+            assertEquals(800, state.co2)
+            assertEquals(14, state.temperatureOutside)
+            assertEquals(false, state.isRefreshing)
+            // reversed order from the DB flow
+            assertEquals(2, state.measureCO2Levels.first().co2Level)
+        }
+
+    @Test
+    fun `keeps defaults and logs when calls fail`() =
+        runTest {
+            coEvery { repository.getCo2AndTemperature() } returns CallStatus.Error("boom")
+            coEvery { weatherRepository.getWeather() } returns CallStatus.Error("boom")
+            every { repository.getCO2ValuesFromDB() } returns flowOf(emptyList())
+
+            val viewModel = createViewModel()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(0, state.temperatureInside)
+            assertEquals(0, state.co2)
+            assertEquals(0, state.temperatureOutside)
+            assertEquals(false, state.isRefreshing)
+            assertEquals(0, state.measureCO2Levels.size)
+        }
+}

--- a/feature/settings/src/main/java/com/timhome/settings/ui/SettingViewModel.kt
+++ b/feature/settings/src/main/java/com/timhome/settings/ui/SettingViewModel.kt
@@ -8,10 +8,20 @@ import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 private const val IP_HOME_ADDRESS_KEY = "ipHomeAddress"
 private const val IS_USE_MOCK_KEY = "isUseMock"
+private const val STOP_TIMEOUT_MILLIS = 5000L
+
+internal data class SettingUiState(
+    val ipAddress: String = "",
+    val isUseMock: Boolean = true,
+)
 
 internal class SettingViewModel
     @AssistedInject
@@ -19,8 +29,17 @@ internal class SettingViewModel
         private val repository: SettingRepository,
         @Assisted private val savedStateHandle: SavedStateHandle,
     ) : ViewModel() {
-        val ipAddress = savedStateHandle.getStateFlow(IP_HOME_ADDRESS_KEY, "")
-        val isUseMock = savedStateHandle.getStateFlow(IS_USE_MOCK_KEY, true)
+        private val ipAddressFlow = savedStateHandle.getStateFlow(IP_HOME_ADDRESS_KEY, "")
+        private val isUseMockFlow = savedStateHandle.getStateFlow(IS_USE_MOCK_KEY, true)
+
+        val uiState: StateFlow<SettingUiState> =
+            combine(ipAddressFlow, isUseMockFlow) { ipAddress, isUseMock ->
+                SettingUiState(ipAddress = ipAddress, isUseMock = isUseMock)
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+                initialValue = SettingUiState(),
+            )
 
         init {
             viewModelScope.launch {
@@ -39,8 +58,8 @@ internal class SettingViewModel
 
         fun onSaveChangClick() {
             viewModelScope.launch {
-                repository.setHomeIpAddress(ipAddress.value)
-                repository.setUseMock(isUseMock.value)
+                repository.setHomeIpAddress(ipAddressFlow.value)
+                repository.setUseMock(isUseMockFlow.value)
             }
         }
 

--- a/feature/settings/src/main/java/com/timhome/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/timhome/settings/ui/SettingsScreen.kt
@@ -40,8 +40,9 @@ internal fun SettingScreen(
     viewModel: SettingViewModel = viewModel(factory = abstractFactory.get()),
 ) {
     HomeTheme {
-        val ipAddress by viewModel.ipAddress.collectAsStateWithLifecycle()
-        val isUseMock by viewModel.isUseMock.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+        val ipAddress = state.ipAddress
+        val isUseMock = state.isUseMock
 
         Column(
             modifier =

--- a/feature/settings/src/test/java/com/timhome/settings/ui/SettingViewModelTest.kt
+++ b/feature/settings/src/test/java/com/timhome/settings/ui/SettingViewModelTest.kt
@@ -1,0 +1,124 @@
+package com.timhome.settings.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.timhome.core.data.repository.SettingRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SettingViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository: SettingRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() = SettingViewModel(repository, SavedStateHandle())
+
+    @Test
+    fun `loads persisted settings into ui state`() =
+        runTest {
+            coEvery { repository.getHomeIpAddress() } returns "192.168.0.1"
+            every { repository.checkIsUseMock() } returns false
+
+            val viewModel = createViewModel()
+            val job = launch { viewModel.uiState.collect {} }
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("192.168.0.1", viewModel.uiState.value.ipAddress)
+            assertEquals(false, viewModel.uiState.value.isUseMock)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `falls back to empty ip when repository returns null`() =
+        runTest {
+            coEvery { repository.getHomeIpAddress() } returns null
+            every { repository.checkIsUseMock() } returns true
+
+            val viewModel = createViewModel()
+            val job = launch { viewModel.uiState.collect {} }
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("", viewModel.uiState.value.ipAddress)
+            assertEquals(true, viewModel.uiState.value.isUseMock)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `onIpAddressEntered updates ui state`() =
+        runTest {
+            coEvery { repository.getHomeIpAddress() } returns ""
+            every { repository.checkIsUseMock() } returns true
+
+            val viewModel = createViewModel()
+            val job = launch { viewModel.uiState.collect {} }
+            dispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onIpAddressEntered("10.0.0.5")
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals("10.0.0.5", viewModel.uiState.value.ipAddress)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `onSetUseMockClick updates ui state`() =
+        runTest {
+            coEvery { repository.getHomeIpAddress() } returns ""
+            every { repository.checkIsUseMock() } returns true
+
+            val viewModel = createViewModel()
+            val job = launch { viewModel.uiState.collect {} }
+            dispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onSetUseMockClick(false)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertEquals(false, viewModel.uiState.value.isUseMock)
+
+            job.cancel()
+        }
+
+    @Test
+    fun `onSaveChangClick persists current values`() =
+        runTest {
+            coEvery { repository.getHomeIpAddress() } returns ""
+            every { repository.checkIsUseMock() } returns true
+
+            val viewModel = createViewModel()
+            val job = launch { viewModel.uiState.collect {} }
+            dispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.onIpAddressEntered("10.0.0.5")
+            viewModel.onSetUseMockClick(false)
+            viewModel.onSaveChangClick()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            coVerify { repository.setHomeIpAddress("10.0.0.5") }
+            coVerify { repository.setUseMock(false) }
+
+            job.cancel()
+        }
+}


### PR DESCRIPTION
## Context
Feature ViewModels violated Google's architecture guidance in three ways: they exposed **mutable** state to the UI (public `MutableStateFlow` fields), spread screen state across **several loose flows** instead of one immutable UI-state object, and **hardcoded `Dispatchers.IO`** inside `viewModelScope.launch(...)`.

This PR applies consistent MVVM + Unidirectional Data Flow to the `:feature:device`, `:feature:home`, and `:feature:settings` ViewModels.

## What changed

**DI (phase 1)** — new `@IoDispatcher` / `@DefaultDispatcher` qualifiers + `DispatchersModule` providing `Dispatchers.IO`/`Default`, exposed as qualified provisions on `CoreComponent` **and** `BaseComponent` (Home's graph depends on Base, which only re-exposes what it declares).

**ViewModels (phases 2–4)** — each screen now exposes one immutable `StateFlow<XxxUiState>` backed by a private `MutableStateFlow`. VMs that do IO (`DeviceDetail`, `DeviceList`, `Home`) inject `@IoDispatcher` and `launch(ioDispatcher)` instead of a hardcoded `Dispatchers.IO`. `Settings` combines its two `SavedStateHandle` flows into a single `SettingUiState` (persistence preserved). Screens collect the single `uiState`.

**Tests (phase 5)** — new JVM unit tests for the device, home and settings ViewModels, enabled by the injected dispatcher (`StandardTestDispatcher` + `runTest`), covering initial state, loaded state and each action/branch. Robolectric only for `DeviceList` (`bundleOf`).

## Decisions
- Dispatcher is injected **into the ViewModels** (injectable test dispatcher per VM).
- **Deferred:** `:feature:auth` migration and deletion of the `core/common/mvi/*` base — auth still uses MVI; the `MviViewModel.kt` marker comment stays for that follow-up.

## Verification
- `:feature:{device,home,settings}:testDebugUnitTest` — green
- `assembleDebug`, `detektDebug`, `ktlintCheck` — green
- Ran on emulator and exercised every refactored screen (home, device list → detail → buy module, settings) — all render correctly from their new `UiState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)