### PR TITLE
Task 06: type-safe navigation with @Serializable routes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     ksp(libs.dagger.compiler)
 
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.kotlinx.serialization.json)
 
     baselineProfile(project(":benchmark"))
 }

--- a/app/src/main/java/com/timhome/modularizationtest/data/BottomNavigationMenuItem.kt
+++ b/app/src/main/java/com/timhome/modularizationtest/data/BottomNavigationMenuItem.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 
 data class BottomNavigationMenuItem(
-    val destinationName: String,
+    val route: Any,
     @StringRes val label: Int,
     @DrawableRes val icon: Int,
     val testTag: String,

--- a/app/src/main/java/com/timhome/modularizationtest/ui/MainActivity.kt
+++ b/app/src/main/java/com/timhome/modularizationtest/ui/MainActivity.kt
@@ -62,6 +62,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -73,6 +74,10 @@ import com.timhome.base.DaggerBaseComponent
 import com.timhome.core.coreComponent
 import com.timhome.core.designsystem.theme.HomeTheme
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.navigation.Devices
+import com.timhome.core.common.navigation.Home
+import com.timhome.core.common.navigation.Setting
+import com.timhome.core.common.navigation.SignIn
 import com.timhome.device.ui.navigation.deviceRoute
 import com.timhome.home.ui.navigation.homeRoute
 import com.timhome.settings.ui.navigation.settingRoute
@@ -121,8 +126,7 @@ class MainActivity : ComponentActivity() {
             DisposableEffect(Unit) {
                 val destinationChangedListener =
                     NavController.OnDestinationChangedListener { _, destination, _ ->
-                        isShowBottomMenu.value =
-                            !destination.route.isNullOrEmpty() && destination.route != "signInScreen"
+                        isShowBottomMenu.value = !destination.hasRoute<SignIn>()
                     }
                 navController.addOnDestinationChangedListener(destinationChangedListener)
                 onDispose {
@@ -162,7 +166,7 @@ class MainActivity : ComponentActivity() {
                     NavHost(
                         modifier = Modifier.padding(padding),
                         navController = navController,
-                        startDestination = "signInScreen",
+                        startDestination = SignIn,
                     ) {
                         signInRoute()
                         homeRoute()
@@ -256,19 +260,19 @@ fun BottomNavigationBar(navController: NavHostController) {
         remember {
             listOf(
                 BottomNavigationMenuItem(
-                    destinationName = "homeScreen",
+                    route = Home,
                     label = R.string.home,
                     icon = R.drawable.ic_home_bottom_menu,
                     testTag = "bnv_home",
                 ),
                 BottomNavigationMenuItem(
-                    destinationName = "devicesScreen",
+                    route = Devices,
                     label = R.string.device,
                     icon = R.drawable.ic_device_bottom_menu,
                     testTag = "bnv_device",
                 ),
                 BottomNavigationMenuItem(
-                    destinationName = "settingScreen",
+                    route = Setting,
                     label = R.string.setting,
                     icon = R.drawable.ic_setting_bottom_menu,
                     testTag = "bnv_setting",
@@ -289,11 +293,11 @@ fun BottomNavigationBar(navController: NavHostController) {
         menuItems.forEach { item ->
             NavigationBarItem(
                 modifier = Modifier.testTag(item.testTag),
-                selected = currentDestination?.hierarchy?.any { it.route == item.destinationName } == true,
+                selected = currentDestination?.hierarchy?.any { it.hasRoute(item.route::class) } == true,
                 onClick = {
-                    if (currentDestination?.route == item.destinationName) return@NavigationBarItem
+                    if (currentDestination?.hasRoute(item.route::class) == true) return@NavigationBarItem
 
-                    navController.navigate(item.destinationName) {
+                    navController.navigate(item.route) {
                         popUpTo(navController.graph.findStartDestination().id) {
                             saveState = true
                         }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
+    implementation(libs.kotlin.serialization.gradlePlugin)
     compileOnly(libs.compose.compiler.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
 }

--- a/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -12,6 +12,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.application")
                 apply("org.jetbrains.kotlin.android")
+                apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("jacoco")
             }
 

--- a/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -15,6 +15,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.android")
+                apply("org.jetbrains.kotlin.plugin.serialization")
                 apply("com.google.devtools.ksp")
                 apply("jacoco")
             }
@@ -38,6 +39,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 add("implementation", libs.findBundle("room").get())
                 add("implementation", libs.findLibrary("dagger").get())
                 add("implementation", libs.findLibrary("androidx-navigation-compose").get())
+                add("implementation", libs.findLibrary("kotlinx-serialization-json").get())
                 add("androidTestImplementation", kotlin("test"))
                 add("testImplementation", kotlin("test"))
                 add("testImplementation", libs.findLibrary("mockk").get())

--- a/core/common/src/main/java/com/timhome/core/common/navigation/Routes.kt
+++ b/core/common/src/main/java/com/timhome/core/common/navigation/Routes.kt
@@ -1,0 +1,28 @@
+package com.timhome.core.common.navigation
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Type-safe navigation destinations shared across features.
+ *
+ * They live here (next to [com.timhome.core.common.NavigationDispatcher]) so features can
+ * reference each other's route contracts without depending on each other's implementations.
+ */
+
+@Serializable
+data object SignIn
+
+@Serializable
+data object Home
+
+@Serializable
+data object Devices
+
+@Serializable
+data class DeviceDetail(val deviceId: Int)
+
+@Serializable
+data class BuyModule(val deviceId: Int)
+
+@Serializable
+data object Setting

--- a/feature/auth/src/main/java/com/timhome/auth/ui/signin/SignInViewModel.kt
+++ b/feature/auth/src/main/java/com/timhome/auth/ui/signin/SignInViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.timhome.auth.domain.IAuthorizationRepository
 import com.timhome.core.common.NavigationDispatcher
 import com.timhome.core.common.mvi.MviViewModel
+import com.timhome.core.common.navigation.Home
+import com.timhome.core.common.navigation.SignIn
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.assisted.Assisted
@@ -47,8 +49,8 @@ internal class SignInViewModel
 
         private fun goHomeScreen() {
             navigationDispatcher.emit {
-                it.navigate("homeScreen") {
-                    popUpTo("signInScreen") { inclusive = true }
+                it.navigate(Home) {
+                    popUpTo<SignIn> { inclusive = true }
                 }
             }
         }

--- a/feature/auth/src/main/java/com/timhome/auth/ui/signin/navigation/SignInRoute.kt
+++ b/feature/auth/src/main/java/com/timhome/auth/ui/signin/navigation/SignInRoute.kt
@@ -9,13 +9,13 @@ import com.timhome.auth.di.DaggerAuthenticationComponent
 import com.timhome.auth.ui.signin.SignInScreen
 import com.timhome.auth.ui.signin.SignInViewModel
 import com.timhome.core.ModularizationApplication
+import com.timhome.core.common.navigation.SignIn
 import com.timhome.core.ui.di.ViewModelFactoryContainer
 import com.timhome.core.ui.slideIntoContainer
 import com.timhome.core.ui.slideOutOfContainer
 
 fun NavGraphBuilder.signInRoute() {
-    composable(
-        route = "signInScreen",
+    composable<SignIn>(
         enterTransition = { slideIntoContainer() },
         exitTransition = { slideOutOfContainer() },
     ) {

--- a/feature/auth/src/test/java/com/timhome/auth/ui/signin/SignInViewModelTest.kt
+++ b/feature/auth/src/test/java/com/timhome/auth/ui/signin/SignInViewModelTest.kt
@@ -73,7 +73,7 @@ class SignInViewModelTest {
 
             val navController = mockk<NavController>(relaxed = true)
             command!!.invoke(navController)
-            verify { navController.navigate(any<String>(), any<NavOptionsBuilder.() -> Unit>()) }
+            verify { navController.navigate(any<Any>(), any<NavOptionsBuilder.() -> Unit>()) }
 
             job.cancel()
         }

--- a/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/buyModule/BuyModuleViewModel.kt
@@ -3,11 +3,12 @@ package com.timhome.device.ui.buyModule
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.timhome.core.common.NavigationDispatcher
+import com.timhome.core.common.navigation.BuyModule
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.device.data.model.ModuleModel
 import com.timhome.device.domain.IDeviceRepository
-import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -38,12 +39,8 @@ internal class BuyModuleViewModel
         val uiState: StateFlow<BuyModuleUiState> = _uiState.asStateFlow()
 
         init {
-            val deviceId = savedStateHandle.get<Int>(SELECTED_DEVICE_ID)
-            val selectedModules =
-                when {
-                    deviceId != null -> repository.getSelectedModuleToBuyByDeviceId(deviceId)
-                    else -> repository.getSelectedModuleToBuy()
-                }
+            val deviceId = savedStateHandle.toRoute<BuyModule>().deviceId
+            val selectedModules = repository.getSelectedModuleToBuyByDeviceId(deviceId)
 
             viewModelScope.launch {
                 selectedModules.stateIn(viewModelScope).collect { list ->

--- a/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/device/DeviceDetailViewModel.kt
@@ -3,13 +3,15 @@ package com.timhome.device.ui.device
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.timhome.core.common.NavigationDispatcher
 import com.timhome.core.common.di.IoDispatcher
+import com.timhome.core.common.navigation.BuyModule
+import com.timhome.core.common.navigation.DeviceDetail
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.device.data.model.ModuleModel
 import com.timhome.device.domain.IDeviceRepository
 import com.timhome.device.domain.models.DeviceModel
-import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -37,16 +39,14 @@ internal class DeviceDetailViewModel
         private val repository: IDeviceRepository,
         @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
-        private val deviceId: Int? = savedStateHandle.get<Int>(SELECTED_DEVICE_ID)
+        private val deviceId: Int = savedStateHandle.toRoute<DeviceDetail>().deviceId
 
         private val _uiState = MutableStateFlow(DeviceDetailUiState())
         val uiState: StateFlow<DeviceDetailUiState> = _uiState.asStateFlow()
 
         init {
-            if (deviceId != null) {
-                viewModelScope.launch(ioDispatcher) {
-                    getSelectedDeviceById(deviceId)
-                }
+            viewModelScope.launch(ioDispatcher) {
+                getSelectedDeviceById(deviceId)
             }
         }
 
@@ -65,7 +65,7 @@ internal class DeviceDetailViewModel
 
         fun buyModules() {
             navigationDispatcher.emit {
-                it.navigate("buyModuleScreen/$deviceId")
+                it.navigate(BuyModule(deviceId))
             }
         }
 

--- a/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListScreen.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListScreen.kt
@@ -18,8 +18,6 @@ import com.timhome.core.ui.viewmodel.ViewModelFactory
 import com.timhome.device.domain.models.DeviceModel
 import com.timhome.device.ui.listDevice.composables.DeviceListItem
 
-const val SELECTED_DEVICE_ID = "deviceId"
-
 @Composable
 internal fun DeviceListScreen(
     abstractFactory: dagger.Lazy<ViewModelFactory>,

--- a/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListViewModel.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/listDevice/DeviceListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.timhome.core.common.NavigationDispatcher
 import com.timhome.core.common.di.IoDispatcher
+import com.timhome.core.common.navigation.DeviceDetail
 import com.timhome.core.ui.viewmodel.ViewModelAssistedFactory
 import com.timhome.device.data.repository.DeviceRepository
 import com.timhome.device.domain.models.DeviceModel
@@ -54,7 +55,7 @@ internal class DeviceListViewModel
 
         fun navigateToDetailScreen(device: DeviceModel) {
             navigationDispatcher.emit {
-                it.navigate("deviceDetailScreen/${device.id}")
+                it.navigate(DeviceDetail(device.id))
             }
         }
 

--- a/feature/device/src/main/java/com/timhome/device/ui/navigation/DeviceRoute.kt
+++ b/feature/device/src/main/java/com/timhome/device/ui/navigation/DeviceRoute.kt
@@ -3,10 +3,11 @@ package com.timhome.device.ui.navigation
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.navArgument
 import com.timhome.core.ModularizationApplication
+import com.timhome.core.common.navigation.BuyModule
+import com.timhome.core.common.navigation.DeviceDetail
+import com.timhome.core.common.navigation.Devices
 import com.timhome.core.ui.di.ViewModelFactoryContainer
 import com.timhome.device.di.DaggerDeviceComponent
 import com.timhome.device.ui.buyModule.BuyModuleScreen
@@ -14,8 +15,7 @@ import com.timhome.device.ui.device.DeviceDetailScreen
 import com.timhome.device.ui.listDevice.DeviceListScreen
 
 fun NavGraphBuilder.deviceRoute() {
-    composable(
-        route = "devicesScreen",
+    composable<Devices>(
         enterTransition = { com.timhome.core.ui.scaleIntoContainer() },
         exitTransition = { com.timhome.core.ui.scaleOutOfContainer() },
     ) {
@@ -29,10 +29,7 @@ fun NavGraphBuilder.deviceRoute() {
             }
         DeviceListScreen(viewModelFactory)
     }
-    composable(
-        route = "deviceDetailScreen/{deviceId}",
-        arguments = listOf(navArgument("deviceId") { type = NavType.IntType }),
-    ) {
+    composable<DeviceDetail> {
         val context = LocalContext.current
         val viewModelFactory =
             remember {
@@ -43,10 +40,7 @@ fun NavGraphBuilder.deviceRoute() {
             }
         DeviceDetailScreen(viewModelFactory)
     }
-    composable(
-        route = "buyModuleScreen/{deviceId}",
-        arguments = listOf(navArgument("deviceId") { type = NavType.IntType }),
-    ) {
+    composable<BuyModule> {
         val context = LocalContext.current
         val viewModelFactory =
             remember {

--- a/feature/device/src/test/java/com/timhome/device/ui/buyModule/BuyModuleViewModelTest.kt
+++ b/feature/device/src/test/java/com/timhome/device/ui/buyModule/BuyModuleViewModelTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.timhome.core.common.NavigationDispatcher
 import com.timhome.device.data.model.ModuleModel
 import com.timhome.device.domain.IDeviceRepository
-import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -19,8 +18,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.math.BigDecimal
 
+@RunWith(RobolectricTestRunner::class)
 class BuyModuleViewModelTest {
     private val dispatcher = StandardTestDispatcher()
     private val repository: IDeviceRepository = mockk(relaxed = true)
@@ -34,6 +36,7 @@ class BuyModuleViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        every { repository.getSelectedModuleToBuyByDeviceId(any()) } returns flowOf(emptyList())
     }
 
     @After
@@ -41,14 +44,13 @@ class BuyModuleViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(deviceId: Int?): BuyModuleViewModel {
-        val handle = SavedStateHandle()
-        if (deviceId != null) handle[SELECTED_DEVICE_ID] = deviceId
+    private fun createViewModel(deviceId: Int = 1): BuyModuleViewModel {
+        val handle = SavedStateHandle(mapOf("deviceId" to deviceId))
         return BuyModuleViewModel(handle, navigationDispatcher, repository)
     }
 
     @Test
-    fun `sums prices and exposes modules for a device`() =
+    fun `sums prices and exposes modules for the routed device`() =
         runTest {
             every { repository.getSelectedModuleToBuyByDeviceId(7) } returns flowOf(listOf(moduleA, moduleB))
 
@@ -60,23 +62,9 @@ class BuyModuleViewModelTest {
         }
 
     @Test
-    fun `falls back to global selection when no deviceId`() =
-        runTest {
-            every { repository.getSelectedModuleToBuy() } returns flowOf(listOf(moduleA))
-
-            val viewModel = createViewModel(deviceId = null)
-            dispatcher.scheduler.advanceUntilIdle()
-
-            assertEquals(BigDecimal(3), viewModel.uiState.value.totalPrice)
-            assertEquals(listOf(moduleA), viewModel.uiState.value.modules)
-        }
-
-    @Test
     fun `removeModule delegates to repository`() =
         runTest {
-            every { repository.getSelectedModuleToBuy() } returns flowOf(emptyList())
-
-            val viewModel = createViewModel(deviceId = null)
+            val viewModel = createViewModel()
 
             viewModel.removeModule(moduleA)
             dispatcher.scheduler.advanceUntilIdle()
@@ -87,9 +75,7 @@ class BuyModuleViewModelTest {
     @Test
     fun `goBack emits a navigation command`() =
         runTest {
-            every { repository.getSelectedModuleToBuy() } returns flowOf(emptyList())
-
-            val viewModel = createViewModel(deviceId = null)
+            val viewModel = createViewModel()
 
             viewModel.goBack()
 

--- a/feature/device/src/test/java/com/timhome/device/ui/device/DeviceDetailViewModelTest.kt
+++ b/feature/device/src/test/java/com/timhome/device/ui/device/DeviceDetailViewModelTest.kt
@@ -5,7 +5,6 @@ import com.timhome.core.common.NavigationDispatcher
 import com.timhome.device.data.model.ModuleModel
 import com.timhome.device.domain.IDeviceRepository
 import com.timhome.device.domain.models.DeviceModel
-import com.timhome.device.ui.listDevice.SELECTED_DEVICE_ID
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -18,10 +17,12 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class DeviceDetailViewModelTest {
     private val dispatcher = StandardTestDispatcher()
     private val repository: IDeviceRepository = mockk(relaxed = true)
@@ -35,6 +36,8 @@ class DeviceDetailViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
+        coEvery { repository.getDeviceById(any()) } returns device
+        coEvery { repository.getModuleToBuyByDeviceId(any()) } returns flowOf(listOf(module))
     }
 
     @After
@@ -42,50 +45,34 @@ class DeviceDetailViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(deviceId: Int? = 1): DeviceDetailViewModel {
-        val handle = SavedStateHandle()
-        if (deviceId != null) handle[SELECTED_DEVICE_ID] = deviceId
+    private fun createViewModel(deviceId: Int = 1): DeviceDetailViewModel {
+        val handle = SavedStateHandle(mapOf("deviceId" to deviceId))
         return DeviceDetailViewModel(handle, navigationDispatcher, repository, dispatcher)
     }
 
     @Test
     fun `initial state is empty before loading`() =
         runTest {
-            coEvery { repository.getDeviceById(1) } returns device
-            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
-
             val viewModel = createViewModel()
 
             assertEquals(DeviceDetailUiState(), viewModel.uiState.value)
         }
 
     @Test
-    fun `loads device and modules when deviceId is present`() =
+    fun `loads device and modules for the routed deviceId`() =
         runTest {
-            coEvery { repository.getDeviceById(1) } returns device
-            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
-
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(deviceId = 1)
             dispatcher.scheduler.advanceUntilIdle()
 
             assertEquals(device, viewModel.uiState.value.device)
             assertEquals(listOf(module), viewModel.uiState.value.modules)
-        }
-
-    @Test
-    fun `does not load anything when deviceId is absent`() =
-        runTest {
-            val viewModel = createViewModel(deviceId = null)
-            dispatcher.scheduler.advanceUntilIdle()
-
-            assertNull(viewModel.uiState.value.device)
-            coVerify(exactly = 0) { repository.getDeviceById(any()) }
+            coVerify { repository.getDeviceById(1) }
         }
 
     @Test
     fun `selectModuleToBuy delegates to repository`() =
         runTest {
-            val viewModel = createViewModel(deviceId = null)
+            val viewModel = createViewModel()
 
             viewModel.selectModuleToBuy(module)
             dispatcher.scheduler.advanceUntilIdle()
@@ -96,8 +83,6 @@ class DeviceDetailViewModelTest {
     @Test
     fun `buyModules emits a navigation command`() =
         runTest {
-            coEvery { repository.getDeviceById(1) } returns device
-            coEvery { repository.getModuleToBuyByDeviceId(1) } returns flowOf(listOf(module))
             val viewModel = createViewModel()
 
             viewModel.buyModules()
@@ -108,7 +93,7 @@ class DeviceDetailViewModelTest {
     @Test
     fun `goBack emits a navigation command`() =
         runTest {
-            val viewModel = createViewModel(deviceId = null)
+            val viewModel = createViewModel()
 
             viewModel.goBack()
 

--- a/feature/home/src/main/java/com/timhome/home/ui/navigation/HomeRoute.kt
+++ b/feature/home/src/main/java/com/timhome/home/ui/navigation/HomeRoute.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.timhome.base.DaggerBaseComponent
 import com.timhome.core.ModularizationApplication
+import com.timhome.core.common.navigation.Home
 import com.timhome.core.ui.di.ViewModelFactoryContainer
 import com.timhome.core.ui.slideIntoContainer
 import com.timhome.core.ui.slideOutOfContainer
@@ -13,8 +14,7 @@ import com.timhome.home.di.DaggerHomeComponent
 import com.timhome.home.ui.HomeScreen
 
 fun NavGraphBuilder.homeRoute() {
-    composable(
-        route = "homeScreen",
+    composable<Home>(
         enterTransition = { slideIntoContainer() },
         exitTransition = { slideOutOfContainer() },
     ) {

--- a/feature/settings/src/main/java/com/timhome/settings/ui/navigation/SettingRoute.kt
+++ b/feature/settings/src/main/java/com/timhome/settings/ui/navigation/SettingRoute.kt
@@ -5,13 +5,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.timhome.core.ModularizationApplication
+import com.timhome.core.common.navigation.Setting
 import com.timhome.core.ui.di.ViewModelFactoryContainer
 import com.timhome.settings.di.DaggerSettingComponent
 import com.timhome.settings.ui.SettingScreen
 
 fun NavGraphBuilder.settingRoute() {
-    composable(
-        route = "settingScreen",
+    composable<Setting>(
         enterTransition = { com.timhome.core.ui.scaleIntoContainer() },
         exitTransition = { com.timhome.core.ui.scaleOutOfContainer() },
     ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ androidxTestExt = "1.2.1"
 androidxTestRules = "1.6.1"
 androidxTestRunner = "1.6.2"
 androidxNavigation = "2.9.3"
+kotlinxSerialization = "1.9.0"
 
 [libraries]
 accompanist-insets = { group = "com.google.accompanist", name = "accompanist-insets", version.ref = "accompanist" }
@@ -69,6 +70,7 @@ androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espres
 androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxUiAutomator" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxNavigation" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp_version" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp_version" }
@@ -99,6 +101,7 @@ firebase-crashlytics-gradlePlugin = { group = "com.google.firebase", name = "fir
 
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 compose-compiler-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+kotlin-serialization-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
@@ -133,4 +136,5 @@ baselineprofile = { id = "androidx.baselineprofile", version = "1.3.4" }
 firebase-perf-plugin = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerfPlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
Replaces all string-based routes/args with `@Serializable` typed destinations (Navigation 2.8+), giving compile-time-safe navigation across every feature. Addresses Google review point #3 (string-based routes).

Route contracts live in `:core:common` (next to `NavigationDispatcher`) so features reference each other's routes without depending on each other's implementations — **zero new feature→feature coupling**, which is what the task's optional `:feature:xxx:api` split would otherwise be for.

## Changes
- **Gradle**: `kotlinx-serialization` plugin + JSON runtime added via the version catalog and applied through the existing library/application convention plugins (same mechanism as `navigation-compose`).
- **Routes**: new `core/common/.../navigation/Routes.kt` — `SignIn`, `Home`, `Devices`, `DeviceDetail(deviceId)`, `BuyModule(deviceId)`, `Setting`.
- **Feature route builders**: rewritten to `composable<T> { … }`; args read via `savedStateHandle.toRoute<T>()` instead of `navArgument`/`NavType`.
- **ViewModels**: typed `navigate(DeviceDetail(id))` / `navigate(BuyModule(id))` / `navigate(Home){ popUpTo<SignIn>{…} }` through `NavigationDispatcher`.
- **MainActivity**: typed `startDestination = SignIn`; bottom-bar visibility and selection use `hasRoute<T>()` / `hasRoute(route::class)`.
- Removed the `SELECTED_DEVICE_ID` string key — `deviceId` is now a typed route field.

## Behavior note
`BuyModule.deviceId` is a non-null `Int` (per the task example), so `BuyModuleViewModel`'s old global-selection fallback — reachable only by navigating without an id, which the typed route now prevents at compile time — was removed along with its test.

## Verification
- `./gradlew assembleDebug detektDebug ktlintCheck` — all green.
- All unit tests pass (two device VM tests use Robolectric because `toRoute` touches `android.os.Bundle`).
- Drove the live app through every transition: sign-in → home → devices → device detail → buy module → back, plus all three bottom-bar tabs. Detail and buy-module screens loaded the correct per-`deviceId` data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)