### PR TITLE
Task 08: CD to Google Play on merge to master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,58 @@
+name: CD
+# Builds a signed release AAB and publishes it to Google Play whenever a PR is merged
+# to master (a merge produces a push to master). The upload step runs only after the
+# build step succeeds, so a broken build never reaches Google Play.
+on:
+  push:
+    branches: [ master ]
+
+# Avoid overlapping releases if several merges land quickly.
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build & publish to Google Play
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 17
+
+      - name: Decode release keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed AAB
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        # github.run_number + 18 keeps the code above the current 18 and always increasing.
+        run: ./gradlew :app:bundleRelease -PversionCode=${{ github.run_number + 18 }}
+
+      - name: Publish to Google Play (internal track)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.timhome.modularizationtest
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          mappingFile: app/build/outputs/mapping/release/mapping.txt
+          track: internal
+          status: completed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         run: ./gradlew detektDebug
   unit_test_job:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,27 +11,27 @@ plugins {
 
 android {
 
-    // TODO https://developer.android.com/studio/publish/app-signing#secure-shared-keystore
     signingConfigs {
         create("release") {
-            keyAlias = "key0admin"
-            keyPassword = ""
-            storePassword = ""
-            // TODO: Use a secure way to store the keystore path and credentials
-            // https://developer.android.com/studio/publish/app-signing#secure-shared-keystore
-            storeFile =
-                if (file("adminTimApp.jks").exists()) {
-                    file("adminTimApp.jks")
-                } else {
-                    null
-                }
+            // Credentials come from environment variables in CI (the CD workflow decodes
+            // them from GitHub Secrets). Locally they fall back to the shared
+            // adminTimApp.jks so manual release builds keep working. When neither the env
+            // keystore nor the local file exists, storeFile stays null and the release
+            // build type falls back to debug signing (see buildTypes.release below).
+            val keystoreFile = file(System.getenv("KEYSTORE_FILE") ?: "adminTimApp.jks")
+            storeFile = keystoreFile.takeIf { it.exists() }
+            keyAlias = System.getenv("KEY_ALIAS") ?: "key0admin"
+            keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+            storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
         }
     }
 
     defaultConfig {
         applicationId = "com.timhome.modularizationtest"
 
-        versionCode = 18
+        // Overridable from CI via -PversionCode=… so every release gets a unique,
+        // ever-increasing code (Play rejects duplicates); defaults to 18 for local builds.
+        versionCode = (project.findProperty("versionCode") as String?)?.toInt() ?: 18
         versionName = "2.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/tasks/08-cd-google-play.md
+++ b/tasks/08-cd-google-play.md
@@ -1,0 +1,131 @@
+# Task 08 — CD: deploy to Google Play on merge to master
+
+**Risk:** medium · **Size:** M
+
+## Background
+CI already runs on `pull_request → master`
+([.github/workflows/ci.yml](../.github/workflows/ci.yml)) with ktlint / lint / detekt /
+unit tests, but every job is `continue-on-error: true`, so nothing actually blocks a
+merge and there is no "successful build" gate. There is no CD: nothing publishes to
+Google Play.
+
+Three blockers must be cleared before CD can work:
+1. **No release signing.** In [app/build.gradle.kts:15-29](../app/build.gradle.kts#L15-L29)
+   `keyPassword` / `storePassword` are empty and `adminTimApp.jks` is absent, so release
+   builds fall back to the debug signature — Play rejects that.
+2. **Hardcoded `versionCode = 18`** ([app/build.gradle.kts:34](../app/build.gradle.kts#L34)) —
+   Play rejects re-uploading the same code.
+3. **No hard build gate** — CD's build job must fail the pipeline (not
+   `continue-on-error`) so deploy only runs on a successful build.
+
+`app/google-services.json` is committed, so CI can build without extra secrets. No
+fastlane in the repo.
+
+## Goal
+On a successful merge to `master`, build a signed release AAB and upload it to Google
+Play Console. Deploy runs **only** when the build succeeds.
+
+## Prerequisites (one-time, done by the account owner — not code)
+1. **Play Console:** app `com.timhome.modularizationtest` must already exist, and the
+   **first AAB must be uploaded manually** (the publishing API cannot create an app).
+2. **Google Cloud:** create a Service Account with access to the Google Play Android
+   Publisher API, invite it in Play Console → *Users & permissions* with release
+   permissions, and download its JSON key.
+
+## GitHub Secrets to add (Settings → Secrets → Actions)
+| Secret | Value |
+|---|---|
+| `KEYSTORE_BASE64` | release keystore (`.jks`), `base64 -w0` encoded |
+| `KEYSTORE_PASSWORD` | store password |
+| `KEY_PASSWORD` | key password |
+| `KEY_ALIAS` | key alias |
+| `PLAY_SERVICE_ACCOUNT_JSON` | contents of the Service Account JSON key |
+
+## Scope / steps
+1. **Refactor signing** in [app/build.gradle.kts](../app/build.gradle.kts) to read
+   keystore + passwords from env vars, keeping the local debug fallback:
+   ```kotlin
+   create("release") {
+       val ksPath = System.getenv("KEYSTORE_FILE") ?: "adminTimApp.jks"
+       storeFile = file(ksPath).takeIf { it.exists() }
+       keyAlias = System.getenv("KEY_ALIAS") ?: "key0admin"
+       keyPassword = System.getenv("KEY_PASSWORD") ?: ""
+       storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+   }
+   ```
+2. **Make versionCode overridable** so CI supplies a unique, ever-increasing value:
+   ```kotlin
+   versionCode = (project.findProperty("versionCode") as String?)?.toInt() ?: 18
+   ```
+   Drive it from `github.run_number` (add an offset if run numbers are below 18, e.g.
+   `run_number + 18`).
+3. **Add `.github/workflows/cd.yml`** triggered on `push` to `master` (this is what a
+   merged PR produces — more reliable than `pull_request: closed`). Two jobs, with
+   `deploy_play` gated behind `needs: build_release`:
+   ```yaml
+   name: CD
+   on:
+     push:
+       branches: [ master ]
+   jobs:
+     build_release:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-java@v4
+           with: { distribution: 'corretto', java-version: 17 }
+         - name: Decode keystore
+           run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > $RUNNER_TEMP/release.jks
+         - name: Build AAB
+           env:
+             KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+             KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+             KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+             KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+           run: ./gradlew :app:bundleRelease -PversionCode=${{ github.run_number }}
+         - uses: actions/upload-artifact@v4
+           with: { name: aab, path: app/build/outputs/bundle/release/app-release.aab }
+
+     deploy_play:
+       needs: build_release          # deploy only on a successful build
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/download-artifact@v4
+           with: { name: aab }
+         - uses: r0adkll/upload-google-play@v1
+           with:
+             serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+             packageName: com.timhome.modularizationtest
+             releaseFiles: app-release.aab
+             track: internal          # start on internal, promote to production later
+             status: completed
+   ```
+4. **Tighten CI into a real gate (recommended):** drop `continue-on-error: true` from at
+   least `unit_test_job`, and enable branch protection on `master` (Require status
+   checks) so broken code can't merge.
+
+## Decisions / defaults
+- **Deploy tool:** `r0adkll/upload-google-play` (no fastlane/ruby needed). Alternatives:
+  Fastlane `supply` or Gradle Play Publisher (Triple-T) — more capable (whatsnew,
+  screenshots) but heavier.
+- **Track:** start with `internal` (instant, no Google review); switch to `production`
+  when confident. For production consider staged rollout via `userFraction`.
+- **versionCode:** from `github.run_number` — no manual bumps, always increasing.
+
+## Watch out for
+- The **first** release must be uploaded manually or `upload-google-play` fails.
+- `github.run_number` must exceed the current `18`, else a duplicate-versionCode
+  conflict — add an offset if needed.
+- Firebase / Crashlytics / baseline-profile make the release build heavy; the first CD
+  run may be slow. Cache `~/.gradle` (as CI already does) to help.
+- Never commit the keystore or Service Account JSON — they live only in Secrets.
+
+## Verification
+- Open a PR, merge to `master`, and confirm the CD workflow runs: `build_release`
+  produces a signed `app-release.aab`, then `deploy_play` succeeds.
+- Confirm the new build appears on the chosen track in Play Console.
+- Confirm a broken build blocks deploy (deploy job stays skipped when build fails).
+
+## Done when
+- Merging to `master` builds a signed AAB and publishes it to Google Play on the internal
+  track, with deploy running only after a successful build.


### PR DESCRIPTION
## Що це
Додає CD: при мерджі PR у `master` збирається підписаний release AAB і публікується в Google Play (internal track). Публікація відбувається **лише після успішної збірки**.

## Зміни
- **`.github/workflows/cd.yml`** (новий): тригер `push → master`. Декодує keystore з `KEYSTORE_BASE64`, робить `:app:bundleRelease` з `versionCode = run_number + 18`, і завантажує через `r0adkll/upload-google-play` на трек `internal`. Кеш Gradle + `concurrency` проти накладання релізів; передає `mappingFile` для деобфускації крешів.
- **`app/build.gradle.kts`**: release-підпис читає keystore/паролі/alias з env (у CI — з GitHub Secrets), fallback на локальний `adminTimApp.jks`. `versionCode` перевизначається через `-PversionCode`.
- **`.github/workflows/ci.yml`**: `unit_test_job` більше не `continue-on-error` — падіння тестів блокує PR.
- **`tasks/08-cd-google-play.md`**: інструкція (секрети, prerequisites, rollout).

## Потрібно налаштувати вручну перед першим релізом
1. **GitHub Secrets:** `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_PASSWORD`, `KEY_ALIAS`, `PLAY_SERVICE_ACCOUNT_JSON`.
2. **Google Play:** застосунок існує + **перший AAB залито вручну**; service account з доступом до релізів.
3. **Branch protection** на `master` → *Require status checks* (`unit_test_job`).

## Перевірено
- `:app:help` конфігурується без property (fallback 18) і з `-PversionCode=99` (шлях `.toInt()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)