### PR TITLE
chore: ignore per-module Gradle build/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.idea/assetWizardSettings.xml
 .DS_Store
 /build
+build/
 /captures
 .externalNativeBuild
 .cxx


### PR DESCRIPTION
## Summary
The root `.gitignore` only contained `/build`, which ignores just the root `build/` directory. In this modularized project every module has its own `build/` folder (`core/common/build`, `core/data/build`, `core/network/build`, …), and none of them matched that pattern. Gradle regenerates these outputs on every build, so ~1,184 generated files kept showing up as unversioned in Android Studio and could not be removed by deleting them manually.

## Change
Add a `build/` pattern (no leading slash) so Gradle build outputs are ignored at **any** directory depth.

## Effect
The unversioned/untracked file count drops from **1,191 to 7** (the remaining 7 are `tasks/*.md` docs, unrelated to this change).

## Notes
- Git tracking only — the on-disk `build/` caches are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)