### PR TITLE
ci: fix invalid versionCode expression in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,8 +44,9 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-        # github.run_number + 18 keeps the code above the current 18 and always increasing.
-        run: ./gradlew :app:bundleRelease -PversionCode=${{ github.run_number + 18 }}
+        # GITHUB_RUN_NUMBER + 18 keeps the code above the current 18 and always increasing.
+        # Arithmetic is done in the shell because GitHub Actions expressions have no '+' operator.
+        run: ./gradlew :app:bundleRelease -PversionCode=$((GITHUB_RUN_NUMBER + 18))
 
       - name: Publish to Google Play (internal track)
         uses: r0adkll/upload-google-play@v1


### PR DESCRIPTION
## Problem
`cd.yml` failed to parse — GitHub reported:

> Invalid workflow file: .github/workflows/cd.yml
> (Line: 48, Col: 14): Unexpected symbol: '+'. Located at position 19 within expression: github.run_number + 18

GitHub Actions expressions (`${{ }}`) have **no arithmetic operators** (only `.`, `[]`, `()`, `!`, comparisons, `&&`/`||`), so `${{ github.run_number + 18 }}` is a syntax error and makes the whole workflow invalid.

## Fix
Move the arithmetic into the shell, where it's supported:

```diff
- run: ./gradlew :app:bundleRelease -PversionCode=${{ github.run_number + 18 }}
+ run: ./gradlew :app:bundleRelease -PversionCode=$((GITHUB_RUN_NUMBER + 18))
```

`GITHUB_RUN_NUMBER` is the env-var equivalent of `github.run_number`, so the resulting `versionCode` is identical — an ever-increasing, unique value for each Google Play upload.

## Scope
Single-file change to `.github/workflows/cd.yml`. No app/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)